### PR TITLE
Fixed compile errors with mrpt-1.4.0

### DIFF
--- a/src/MapBuilder_MRPT.cpp
+++ b/src/MapBuilder_MRPT.cpp
@@ -187,9 +187,6 @@ bool MapBuilder_MRPT::initialize(MapBuilderParam& param_)
 	else if (param.ICP_algorithm == "icpLevenbergMarquardt") {
 		m_MapBuilder.ICP_params.ICP_algorithm = icpLevenbergMarquardt;
 	}
-	else if (param.ICP_algorithm == "icpIKF") {
-		m_MapBuilder.ICP_params.ICP_algorithm = icpIKF;
-	}
 
 	m_MapBuilder.ICP_params.onlyClosestCorrespondences = param.ICP_onlyClosestCorrespondences;
 	m_MapBuilder.ICP_params.onlyUniqueRobust = param.ICP_onlyUniqueRobust;


### PR DESCRIPTION
mrpt-1.4.0 では未実装の Iterative Kalman Filter (IKF) の enum が削除されていたため，コンパイルエラーが発生していました．
https://github.com/MRPT/mrpt/issues/177

もし修正方法に問題無いようでしたら取り込んでいただけると嬉しいです．
